### PR TITLE
Fix bug causing crashes in UI when tabular reports are being editted

### DIFF
--- a/src/modules/reports/ReportsTree.jsx
+++ b/src/modules/reports/ReportsTree.jsx
@@ -103,7 +103,7 @@ class ReportsTree extends React.Component{
                     <MenuItem icon="th" text="View report" onClick={(ev) => {ev.preventDefault(); this.showReportDataTab(node.label, node.reportId);}}/>
 					{node.inBuilt === true ? "" : <MenuItem icon="graph-remove" text="Delete report" onClick={(ev) => {ev.preventDefault(); this.removeReport(node.reportId);}}/> }	
 					{ node.inBuilt === false && node.type === 'composite' ? <MenuItem icon="edit" text="Edit report" onClick={(ev) => {ev.preventDefault(); this.createCompositeReport(node.reportId)}} /> : "" }
-					{ node.inBuilt === false && node.type !== 'composite' ? <MenuItem icon="edit" text="Edit report" onClick={(ev) => {ev.preventDefault(); this.createCompositeReport(node.reportId)}} /> : "" }
+					{ node.inBuilt === false && node.type !== 'composite' ? <MenuItem icon="edit" text="Edit report" onClick={(ev) => {ev.preventDefault(); this.showEditTab(node.reportId)}} /> : "" }
 					
                 </Menu>,
                 { left: e.clientX, top: e.clientY },


### PR DESCRIPTION
Clicking *edit report* in the report tree panel crashes the app UI
if the report is a tabular report